### PR TITLE
Add mp_starting_losses 1 to the cfg

### DIFF
--- a/cfg/live.cfg
+++ b/cfg/live.cfg
@@ -76,6 +76,7 @@ mp_roundtime 1.92
 mp_roundtime_defuse 1.92
 mp_solid_teammates 1
 mp_spawnprotectiontime 5
+mp_starting_losses 1
 mp_startmoney 800
 mp_t_default_grenades ""
 mp_t_default_melee weapon_knife


### PR DESCRIPTION
Common majors, faceit, and the matchmaking of Valve all have mp_starting_losses 1. Without setting it explicitly it defaults to zero causing a wrong economy as after a first round loss in a half one gets 1400 instead of 1900.